### PR TITLE
allow_missing_blocks + more providers

### DIFF
--- a/issue_11645/oe/gateway.toml
+++ b/issue_11645/oe/gateway.toml
@@ -18,6 +18,7 @@ interface = "all"
 cors = ["all"]
 apis = ["web3", "eth", "pubsub", "net", "parity", "parity_set", "parity_pubsub", "rpc", "personal"]
 hosts = ["all"]
+allow_missing_blocks = true
 
 [websockets]
 disable = false

--- a/issue_11645/truffle/truffle-config.js
+++ b/issue_11645/truffle/truffle-config.js
@@ -25,8 +25,14 @@
 // const mnemonic = fs.readFileSync(".secret").toString().trim();
 
 
+const net = require('net');
+const Web3 = require("web3");
 const HDWalletProvider = require('@truffle/hdwallet-provider');
-const provider = new HDWalletProvider("b8cce89a80adce69775a568677ade40be0c5b3061fcb866aa09ba1b0261a24bc", "http://localhost:8545");
+
+const provider    = new Web3.providers.HttpProvider("http://localhost:8545");
+const hdProvider  = new HDWalletProvider("b8cce89a80adce69775a568677ade40be0c5b3061fcb866aa09ba1b0261a24bc", "http://localhost:8545");
+const wsProvider  = new Web3.providers.WebsocketProvider("ws://localhost:8546");
+const ipcProvider = new Web3.providers.IpcProvider('../oe/node4/jsonrpc.ipc', net);
 
 module.exports = {
   /**
@@ -75,7 +81,10 @@ module.exports = {
 
     // Useful for private networks
     private: {
-       provider: () => provider,
+//       provider: () => provider,
+//       provider: () => hdProvider,
+//       provider: () => wsProvider,
+       provider: () => ipcProvider,
        network_id: 43,
        gasPrice: 0,
        gas: 6000000         // Ropsten has a lower block limit than mainnet


### PR DESCRIPTION
[x] try to use `allow_missing_blocks = true`

no issue now with the following provider (no check means - there is an issue):
[x] `HttpProvider`
[x] `HDWalletProvider` (based on `HttpProvider`)
[ ] `WebsocketProvider`
[] `IpcProvider`
